### PR TITLE
Updated shebang in shell scripts

### DIFF
--- a/scripts/buildtools
+++ b/scripts/buildtools
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 
 #cd $1
@@ -9,7 +9,7 @@ do
 	echo
 	echo "## " $tool
 	echo "<pre class=faust-tools>"
-	sh $tool -help | sed -e 's/\</\&lt;/g'
+	$tool -help | sed -e 's/\</\&lt;/g'
 	echo "</pre>"
 	echo
 

--- a/scripts/make-example
+++ b/scripts/make-example
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 
 GROUP=$1


### PR DESCRIPTION
Hi!

Following https://github.com/grame-cncm/faust/pull/1048, this commit updates two scripts.
No bashisms this time but we don't use _sh_ explicitly anymore in .`/scripts/buildtools` and set shebangs to `!#/bin/bash` for both scripts.

When building the faust2x docs, buildtools run scripts written for _bash_ with _sh_. While _bash_ can perfectly run _sh_ scripts, the opposite isn't true and with this change we rely on called scripts shebang to select the correct shell interpreter.
An example is `faust/tools/faust2appls/faustoptflags` that returns errors when run by _sh_

Regards,
Yoann LE BORGNE