### PR TITLE
Make faustdoc standalone at runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,9 @@ mkdocs/docs/qreference/
 
 mkdocs/docs/rail/[0-9]*
 
+mkdocs/docs/js
+mkdocs/docs/css
+
 src/examples/ambisonics.md
 src/examples/analysis.md
 src/examples/bela.md

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,8 @@ help:
 	@echo "This Makefile is intended to generate the faust documentation"
 	@echo "======================================================="
 	@echo "Available targets are:"
-	@echo "  install  : install the required components"
+	@echo "  install  : install the required Python components"
+	@echo "  dependencies  : download the required css and js dependencies"
 	@echo "  build    : build the web site"
 	@echo "  serve    : launch the mkdoc server"
 	@echo "Development specific targets are available:"
@@ -68,6 +69,7 @@ test:
 ####################################################################
 build:
 	$(MAKE) all
+	$(MAKE) dependencies
 	cd $(MKDIR) && mkdocs build
 	git checkout docs/CNAME
 	
@@ -159,6 +161,13 @@ $(FAUSTDIR):
 	@echo "   - set FAUSTDIR to the faust projet location in this Makefile"
 	@echo "   - call $(MAKE) FAUSTDIR=faust_projet_path"
 	@false;
+
+####################################################################
+dependencies:
+	curl -L --create-dirs https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/github.min.css -o ./mkdocs/docs/css/github.min.css
+	curl -L --create-dirs https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js -o ./mkdocs/docs/js/highlight.min.js
+	curl -L --create-dirs https://cdn.jsdelivr.net/npm/@grame/faust-web-component@0.4.1/dist/faust-web-component.js -o ./mkdocs/docs/js/faust-web-component.js
+	curl -L --create-dirs https://github.com/mathjax/MathJax/archive/2.7.1.zip -o ./mkdocs/docs/js/2.7.1.zip && unzip -o ./mkdocs/docs/js/2.7.1.zip -d ./mkdocs/docs/js/
 
 ####################################################################
 install:

--- a/mkdocs/mkdocs.yml
+++ b/mkdocs/mkdocs.yml
@@ -86,10 +86,11 @@ plugins:
 
 extra_css:
    - '/css/quickref.css'
+   - '/css/github.min.css'
    - '/rail/railroad-diagrams.css'
 
 extra_javascript:
-  - https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML
+  - '/js/faust-web-component.js'
 
 markdown_extensions:
     - mdx_math

--- a/mkdocs/theme/base.html
+++ b/mkdocs/theme/base.html
@@ -27,45 +27,18 @@
     <link href="{{ 'css/bootstrap.min.css'|url }}" rel="stylesheet">
     <link href="{{ 'css/font-awesome.min.css'|url }}" rel="stylesheet">
     <link href="{{ 'css/base.css'|url }}" rel="stylesheet">
-    {%- if config.theme.highlightjs %}
-    <link rel="stylesheet"
-        href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/{{ config.theme.hljs_style }}.min.css">
-    {%- endif %}
     {%- for path in config['extra_css'] %}
     <link href="{{ path|url }}" rel="stylesheet">
     {%- endfor %}
     {%- endblock %}
 
     {%- block libs %}
-
     <script src="{{ 'js/jquery-3.6.0.min.js'|url }}" defer></script>
     <script src="{{ 'js/bootstrap.min.js'|url }}" defer></script>
-    {%- if config.theme.highlightjs %}
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"></script>
-    {%- for lang in config.theme.hljs_languages %}
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/languages/{{lang}}.min.js"></script>
-    {%- endfor %}
+    <script src="{{ 'js/MathJax-2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML'|url }}" defer></script>
+    <script src="{{ 'js/highlight.min.js'|url }}" defer></script>
     <script>hljs.initHighlightingOnLoad();</script>
-    {%- endif %}
     {%- endblock %}
-
-    {%- block analytics %}
-    {%- if config.google_analytics %}
-    <script>
-        (function (i, s, o, g, r, a, m) {
-            i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function () {
-                (i[r].q = i[r].q || []).push(arguments)
-            }, i[r].l = 1 * new Date(); a = s.createElement(o),
-                m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m)
-        })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
-
-        ga('create', '{{ config.google_analytics[0] }}', '{{ config.google_analytics[1] }}');
-        ga('send', 'pageview');
-    </script>
-    {%- endif %}
-    {%- endblock %}
-
-    {%- block extrahead %} {% endblock %}
 </head>
 
 <body{% if page and page.is_homepage %} class="homepage" {% endif %}>
@@ -205,9 +178,6 @@
 
     {% if 'search' in config['plugins'] %}{%- include "search-modal.html" %}{% endif %}
     {%- include "keyboard-modal.html" %}
-
-    <script src="https://cdn.jsdelivr.net/npm/@grame/faust-web-component@0.4.1/dist/faust-web-component.js"
-        defer></script>
     </body>
 
 </html>


### PR DESCRIPTION
faustdoc needs the following dependencies:

    https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/github.min.css
    https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js
    https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js
    https://cdn.jsdelivr.net/npm/@grame/faust-web-component@0.4.1/dist/faust-web-component.js
The first three are coming from the default mkdocs theme. The last one is from Grame.

Previously they were called while browsing any faustdoc page. For multiple reasons (security, functionality, privacy) it should be avoided if possible.

With this set of modifications they are now downloaded and embedded at build time, making faustdoc standalone at runtime as it is not relying on other internet services anymore.