### PR TITLE
Fix CSS problem affecting scrollable nav sidebar in Chrome.

### DIFF
--- a/mkdocs/theme/css/base.css
+++ b/mkdocs/theme/css/base.css
@@ -271,30 +271,49 @@ footer {
     display: block;
     padding: 5px 20px;
     z-index: 1;
+    /* Hover/focus/active indicators are absolute wrt. their corresponding anchor. */
+    position: relative;
 }
-.bs-sidebar .nav > li > a:hover,
-.bs-sidebar .nav > li > a:focus {
-    text-decoration: none;
-    border-right: 1px solid;
+
+/*
+- Indicate the hierarchy of active nav nodes.
+- Highlight node on hover/focus.
+- Do so in a way that doesn't disturb layout.
+ */
+.bs-sidebar .nav > li > a:hover::after,
+.bs-sidebar .nav > li > a:focus::after,
+.bs-sidebar .nav > li > a.active::after {
+    content: '';
+    position: absolute;
+    right: 0;
+    top: 0;
+    width: 2px;
+    height: 100%;
+    background-color: currentColor;
 }
+
+/*
+The default theme makes active nav elements bold, but note that it doesn't
+permit, out of the box, a fixed nav height with scrollable content (See, e.g.,
+https://www.mkdocs.org/about/release-notes/). The way that bootstrap.js
+manages changes to the active nav element (and its parents) --- removing the
+.active class from one set of elements, adding it to another --- causes anchors
+to be reset to normal weight, then made bold, which (in Chrome at least) can
+cause sudden, unexpected vertical shifts in the nav.
+*/
 .bs-sidebar .nav > li > a.active,
 .bs-sidebar .nav > li > a.active:hover,
 .bs-sidebar .nav > li > a.active:focus {
-    font-weight: bold;
     background-color: transparent;
-    border-right: 1px solid;
 }
 
 .bs-sidebar .nav .nav .nav {
     margin-left: 1em;
 }
 
-.bs-sidebar .nav > li > a {
+/* Emphasise the top level nav item. */
+.bs-sidebar .nav:first-child > li:first-child > a {
     font-weight: bold;
-}
-
-.bs-sidebar .nav .nav > li > a {
-    font-weight: normal;
 }
 
 .headerlink {
@@ -307,8 +326,6 @@ footer {
 h1:hover .headerlink, h2:hover .headerlink, h3:hover .headerlink, h4:hover .headerlink, h5:hover .headerlink, h6:hover .headerlink{
     display:inline-block;
 }
-
-
 
 .admonition {
     padding: 15px;


### PR DESCRIPTION
Scrolling the sidebar, and mousing-over active elements can cause the vertical scroll to behave erratically, so:
- Use pseudo-element as .active indicator rather than border.
- Don't make active nav elements bold (the default theme doesn't do this well anyway, see mkdocs.org).

Checked in Chrome 132 and Firefox 134.